### PR TITLE
Update call to entitlements to avoid deprecated duration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,6 @@ Metrics/MethodLength:
 Style/FrozenStringLiteralComment:
   Exclude:
     - 'bin/*'
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Tarpon::Client
 Tarpon::Client
   .subscriber('app_user_id')
   .entitlements('entitlement_id')
-  .grant_promotional(duration: 'daily', start_time_ms: 1582023714931)
+  .grant_promotional(start_time_ms: 1582023714931, end_time_ms: 1582023715854)
 ```
 
 Be aware that RevenueCat doesn't create the subscriber automatically. If the `app_user_id` doesn't exist, the request will fail with a `404 Not Found`. Perform a `Tarpon::Client.subscriber('app_user_id').get_or_create` beforehand to make sure the subscriber exists when granting promotional entitlements:
@@ -113,7 +113,7 @@ Tarpon::Client.subscriber('app_user_id').get_or_create # subscriber is created
 Tarpon::Client
   .subscriber('app_user_id')
   .entitlements('entitlement_id')
-  .grant_promotional(duration: 'daily', start_time_ms: 1582023714931)
+  .grant_promotional(start_time_ms: 1582023714931, end_time_ms: 1582023715854)
 ```
 
 Check the [endpoint reference](https://docs.revenuecat.com/reference#grant-a-promotional-entitlement) for valid `duration` values, Tarpon does not perform any input validation.

--- a/lib/tarpon/request/base.rb
+++ b/lib/tarpon/request/base.rb
@@ -17,7 +17,7 @@ module Tarpon
 
       protected
 
-      def perform(method:, path:, key:, headers: {}, body: nil, &block)
+      def perform(method:, path:, key:, headers: {}, body: nil, &block) # rubocop:disable Metrics/AbcSize
         HTTP
           .timeout(@client.timeout)
           .then { |http_client| @client.http_middleware.call(http_client) }

--- a/lib/tarpon/request/subscriber.rb
+++ b/lib/tarpon/request/subscriber.rb
@@ -8,7 +8,7 @@ module Tarpon
         @app_user_id = app_user_id
       end
 
-      def get_or_create(&block) # rubocop:disable Naming/AccessorMethodName
+      def get_or_create(&block)
         perform(method: :get, path: path, key: :public, &block)
       end
 

--- a/lib/tarpon/request/subscriber/entitlement.rb
+++ b/lib/tarpon/request/subscriber/entitlement.rb
@@ -10,9 +10,9 @@ module Tarpon
           @entitlement_identifier = entitlement_identifier
         end
 
-        def grant_promotional(duration:, start_time_ms: nil, &block)
+        def grant_promotional(start_time_ms: nil, end_time_ms: nil, &block)
           body = {
-            duration: duration,
+            end_time_ms: end_time_ms,
             start_time_ms: start_time_ms
           }
 

--- a/lib/tarpon/request/subscriber/entitlement.rb
+++ b/lib/tarpon/request/subscriber/entitlement.rb
@@ -12,8 +12,8 @@ module Tarpon
 
         def grant_promotional(start_time_ms: nil, end_time_ms: nil, &block)
           body = {
-            end_time_ms: end_time_ms,
-            start_time_ms: start_time_ms
+            start_time_ms: start_time_ms,
+            end_time_ms: end_time_ms
           }
 
           perform(method: :post, path: "#{path}/promotional", key: :secret, body: body, &block)

--- a/lib/tarpon/request/subscriber/offering.rb
+++ b/lib/tarpon/request/subscriber/offering.rb
@@ -12,7 +12,8 @@ module Tarpon
         end
 
         def list(platform, &block)
-          response = perform(method: :get, path: path.to_s, headers: { 'x-platform': platform.to_s }, key: :public, &block)
+          response =
+            perform(method: :get, path: path.to_s, headers: { 'x-platform': platform.to_s }, key: :public, &block)
           return response unless response.success?
 
           Tarpon::Entity::Offerings.new(**response.raw)

--- a/spec/tarpon/client/subscriber_spec.rb
+++ b/spec/tarpon/client/subscriber_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Tarpon::Client do
       describe '.grant_promotional' do
         it_behaves_like 'an http call to RevenueCat responding with subscriber object',
                         method: :post, api_key: :secret do
-          let(:body) { { duration: 'weekly', start_time_ms: 123 } }
+          let(:body) { { start_time_ms: 123, end_time_ms: 345 } }
           let(:client_call) { entitlement.grant_promotional(**body) }
           let(:uri) do
             "#{described_class.base_uri}/subscribers/#{app_user_id}/entitlements/#{entitlement_id}/promotional"


### PR DESCRIPTION
The duration param is now deprecated in Stripe API v1, instead we will be using end_time_ms

I decided to create the commit myself instead of keeping up to date with the fork because:

1. There were merge conflicts if we tried to sync. There are only 2 commits in this repo ahead from the parent fork, but still, I considered outside-of-scope solving that as part of this upsell MVP test.
2. I preferred to fully remove the duration param to avoid any usage